### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,4 +2,4 @@
 This is a QR Code Encoder written in Objective-C. The code has originally been ported by myang-git from Psytec library https://github.com/myang-git/QR-Code-Encoder-for-Objective-C. The drawback was that myang-git's project has to be compiled using a c++ compiler. Integrating this into your objective-c based project may therefore be cumbersome. That's why I ported this library to Objective-C.
 
 # Installation
-The QR Code Encoder is wrapped into a Cocoa framework. Drag the QRCodeEncoder XCode project to your own project in XCode. Drag and drop the QRCodeEncoder.framework item from the "Products" group to the linked binaries in the "Build Phases" tab.
+The QR Code Encoder is wrapped into a Cocoa framework. Drag the QRCodeEncoder Xcode project to your own project in Xcode. Drag and drop the QRCodeEncoder.framework item from the "Products" group to the linked binaries in the "Build Phases" tab.


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
